### PR TITLE
feat: rename function output role to `tool`

### DIFF
--- a/small/README.md
+++ b/small/README.md
@@ -101,10 +101,10 @@ For now, the model is only capable of calling one function at a time.
 
 ## Function Call Response
 
-The model expects the function call response to be provided from a role `fn` right after the function call request:
+The model expects the function call response to be provided from a role `tool` right after the function call request:
 
 ```
-<|im_start|>fn
+<|im_start|>tool
 {"result": "87cc47fbc865a290d7c7de4be3c893175c51a566b3"}<|im_end|>
 ```
 
@@ -132,7 +132,7 @@ You are a helpful assistant.<|im_end|>
 Generate a password, 42 characters long<|im_end|>
 <|im_start|>assistant
 <|fn_start|>{"name": "generate_password", "arguments": {"length": 42}}<|fn_end|><|im_end|>
-<|im_start|>fn
+<|im_start|>tool
 {"result": "87cc47fbc865a290d7c7de4be3c893175c51a566b3"}<|im_end|>
 <|im_start|>assistant
 Here is your random password: 87cc47fbc865a290d7c7de4be3c893175c51a566b3. Please make sure to save it in a secure place.<|im_end|>

--- a/small/train.py
+++ b/small/train.py
@@ -36,7 +36,7 @@ class ScriptArguments:
 
 # Dirty hack for `DataCollatorForCompletionOnlyLM` from `trl` to work correctly with our conversation template.
 # The original implementation assumes there is always a `user/assistant/user/assistant/...` sequence of messages,
-# which is not true for our case, since it's possible to have a `system/user/assistant/fn/assistant/user/...` order.
+# which is not true for our case, since it's possible to have a `system/user/assistant/tool/assistant/user/...` order.
 class DataCollatorForCompletionOnlyLM(DataCollatorForLanguageModeling):
     def __init__(
         self,
@@ -124,7 +124,7 @@ def from_to_name(from_name):
     elif from_name == "system":
         return "system"
     elif from_name == "function_response":
-        return "fn"
+        return "tool"
     else:
         raise ValueError(f"Unknown message type {from_name}")
 


### PR DESCRIPTION
For ease of adoption, it would be better to use the same name for the function call output role as OpenAI does.